### PR TITLE
Fix duplicate key presses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1833,7 +1833,7 @@ dependencies = [
 
 [[package]]
 name = "speedy-reader"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "anyhow",
  "chrono",

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ use crossterm::{
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
+use crossterm::event::{KeyEventKind, KeyEventState};
 use ratatui::prelude::*;
 
 mod ai;
@@ -113,12 +114,14 @@ async fn run_app<B: Backend>(terminal: &mut Terminal<B>, app: &mut App) -> Resul
         // Poll for events with timeout to allow async operations
         if event::poll(Duration::from_millis(100))? {
             if let Event::Key(key) = event::read()? {
-                if let Some(action) =
-                    handle_key_event(key, app.tag_input_active, app.feed_input_active, app.opml_input_active, app.opml_export_active, app.show_help)
-                {
-                    let should_quit = app.handle_action(action).await?;
-                    if should_quit {
-                        return Ok(());
+                if key.kind == KeyEventKind::Press {
+                    if let Some(action) =
+                        handle_key_event(key, app.tag_input_active, app.feed_input_active, app.opml_input_active, app.opml_export_active, app.show_help)
+                    {
+                        let should_quit = app.handle_action(action).await?;
+                        if should_quit {
+                            return Ok(());
+                        }
                     }
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ use crossterm::{
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
-use crossterm::event::{KeyEventKind, KeyEventState};
+use crossterm::event::{KeyEventKind};
 use ratatui::prelude::*;
 
 mod ai;


### PR DESCRIPTION
This fixes an issue I was having with the app. It was impossible to paste or type any url as every key press was duplicated.
now it only handles the initial key press as the key event, and ignores the key release event.